### PR TITLE
Fix regex for detecting keys

### DIFF
--- a/src/commands/jsonToAtomMap.js
+++ b/src/commands/jsonToAtomMap.js
@@ -7,7 +7,7 @@ function handler() {
 
   var atom_map = highlight.replace(/' '/g, '')
   atom_map = atom_map.replace(/{/g, '%{')
-  atom_map = atom_map.replace(/"([a-zA-Z0-9-]+)":/g, '\$1\: ');
+  atom_map = atom_map.replace(/"(\w+)":/g, '\$1\: ');
 
   editor.edit(builder => {
     if (selection.isEmpty) {

--- a/src/commands/jsonToStringMap.js
+++ b/src/commands/jsonToStringMap.js
@@ -7,7 +7,7 @@ function handler() {
 
   var string_map = highlight.replace(/' '/g, '')
   string_map = string_map.replace(/{/g, '%{')
-  string_map = string_map.replace(/"([a-zA-Z0-9-]+)":/g, '\"$1\" =>')
+  string_map = string_map.replace(/"(\w+)":/g, '\"$1\" =>')
 
   editor.edit(builder => {
     if (selection.isEmpty) {

--- a/src/commands/mapToJson.js
+++ b/src/commands/mapToJson.js
@@ -9,12 +9,12 @@ function handler() {
 
   // This logic is terrible and needs to be improved,
   // specially the atom map RegEx.
-  if (highlight.match(/"([a-zA-Z0-9-]+)" =>/g)) {
+  if (highlight.match(/"(\w+)"\s*=>/g)) {
     // It's a string map!
-    json = json.replace(/"([a-zA-Z0-9-]+)" => /g, '\"$1\": ')
+    json = json.replace(/"(\w+)"\s*=>\s*/g, '\"$1\": ')
   } else {
     // It's an atom map! (please send help)
-    json = json.replace(/([a-zA-Z0-9-]+): /g, '\"$1\": ')
+    json = json.replace(/(\w+):\s*/g, '\"$1\": ')
   }
 
   editor.edit(builder => {


### PR DESCRIPTION
Fixes #1
Fixes #6

Handles more cases for different map/object keys:

```elixir
%{
  one_two: "excellent"
}

# Map to JSON converts to:
{
  "one_two": "excellent"
}
```

```elixir
%{
  "one_two": "excellent"
}

# Map to JSON converts to:
{
  "one_two": "excellent"
}
```

```js
{
  "one_two": "excellent"
}

// JSON to atom map converts to
{
  one_two: "excellent"
}
```

```js
{
  "one_two": "excellent"
}

// JSON to strig key map converts to
{
  "one_two" => "excellent"
}
```